### PR TITLE
Don't error out on execution

### DIFF
--- a/ipyx/x.py
+++ b/ipyx/x.py
@@ -72,7 +72,10 @@ class X(DOMWidget):
 
     def _compute(self) -> None:
         if self._operation:
-            exec(self._operation)
+            try:
+                exec(self._operation)
+            except Exception:
+                pass
 
 
 def make_unary(name: str, sign: str = ""):


### PR DESCRIPTION
In order to support out-of-order execution, undefined variables must be allowed.