### PR TITLE
Separate widget from X

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "x1 = X(0)\n",
-    "x1"
+    "x1.w"
    ]
   },
   {
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "x2 = x1 + 1\n",
-    "x2"
+    "x2.w"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "x3 = f(x2 / 10)\n",
-    "x3"
+    "x3.w"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "x4 = f(x3)\n",
-    "x4"
+    "x4.w"
    ]
   },
   {
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "a = X(0)\n",
-    "a"
+    "a.w"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "outputs": [],
    "source": [
     "b = X(0)\n",
-    "b"
+    "b.w"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "outputs": [],
    "source": [
     "c = foo(a, b=b)\n",
-    "c"
+    "c.w"
    ]
   },
   {


### PR DESCRIPTION
This fixes a performance issue:
```python
# cell 1
from ipyx import X

# cell 2
a = X(0)
a.w

# cell 3
while True:
    a.v = (a + 1).v
```
The last line could be replaced with `a.v = a.v + 1`, but `a.v = (a + 1).v` simulates what [akernel](https://github.com/davidbrochart/akernel) does: it first creates an `X` object from the expression.
Previously, creating an `X` object was very costly, because it created a widget. Now, an `X` object doesn't have an associated widget until `a.w` is called.
Notice that showing the widget must now be done with `a.w` (`a` shows the current value, but it won't react to a value change).

Partially fixes #3.